### PR TITLE
Debian installer: Installing and removing makes more sense

### DIFF
--- a/INSTALL/debian-install.sh
+++ b/INSTALL/debian-install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Colors
+RED='\033[0;31m'
+LRED="\033[1;31m"
+BLUE="\033[0;34m"
+LBLUE="\033[1;34m"
+GREEN="\033[0;32m"
+LGREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+CYAN="\033[0;36m"
+LCYAN="\033[1;36m"
+PURPLE="\033[0;35m"
+LPURPLE="\033[1;35m"
+BWHITE="\e[1m"
+NC='\033[0m' # No Color
+
+
+function checkRoot() {
+  if [[ $EUID -ne 0 ]]; then
+    printf "${LRED}This script must be run as root${NC}\n" 1>&2
+     exit 1
+  fi
+}
+
+function getDeps() {
+  printf "${LGREEN}Installing required dependencies...${NC}\n"
+
+  apt-get install -y clang make pkg-config lua5.3-dev
+}
+
+
+function installTuxc() {
+  if [ ! -f /usr/bin/tux ];then
+      printf "${LGREEN}Building executable...${NC}\n"
+      make -C ../ 
+      printf "${LGREEN}Installing...${NC}\n"
+      make install -C ../
+    else
+      printf "${LGREEN}Cleaning build environment...${NC}\n"
+      make clean -C ../
+      printf "${LGREEN}Building executable...${NC}\n"
+      make -C ../
+      printf "${LGREEN}Installing...${NC}\n"
+      make install -C ../
+  fi
+
+}
+
+checkRoot
+getDeps
+installTuxc

--- a/INSTALL/debian-uninstall.sh
+++ b/INSTALL/debian-uninstall.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Colors
+RED='\033[0;31m'
+LRED="\033[1;31m"
+BLUE="\033[0;34m"
+LBLUE="\033[1;34m"
+GREEN="\033[0;32m"
+LGREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+CYAN="\033[0;36m"
+LCYAN="\033[1;36m"
+PURPLE="\033[0;35m"
+LPURPLE="\033[1;35m"
+BWHITE="\e[1m"
+NC='\033[0m' # No Color
+
+
+function checkRoot() {
+  if [[ $EUID -ne 0 ]]; then
+    printf "${LRED}This script must be run as root${NC}\n" 1>&2
+     exit 1
+  fi
+}
+
+
+
+function askUninstall() {
+
+    printf "${LRED}Are you sure you want to uninstall Tuxc? [y/n]${NC} "
+    read choice
+    
+    if [ "${choice}" = y ] || [ "${choice}" = Y ] || [ "${choice}" = yes ] || [ "${choice}" = "YES" ];then
+        uninstallTuxc
+    else
+        printf "${LCYAN}Uninstall aborted!${NC}\n"
+    fi
+
+
+}
+
+
+function uninstallTuxc() {
+  if [ ! -f /usr/bin/tux ];then
+    printf "${LRED}Tux is not installed${NC}\n"
+    exit
+
+  else
+    printf "${LRED}Uninstalling...${NC}\n"
+
+    make uninstall -C ../
+
+    if [ ! -f /usr/bin/tux ];then
+      printf "${LGREEN}Tux is uninstalled${NC}\n"
+    else
+      printf "${LRED}There was a problem removing Tux from your system${NC}\n"
+    fi
+  fi
+}
+
+
+function removeDeps() {
+    printf "${LRED}Do you want to remove all dependencies? [y/n]:${NC} "
+    read choice
+
+    if [ "${choice}" = y ] || [ "${choice}" = Y ] || [ "${choice}" = yes ] || [ "${choice}" = "YES" ];then
+        apt-get -y remove clang make pkg-config lua5.3-dev
+    else
+        printf "${LCYAN}Keeping dependencies\n${NC}"
+        exit 0;
+    fi
+
+
+}
+
+checkRoot
+askUninstall
+removeDeps


### PR DESCRIPTION
* Slimmed down the installer to only focus on installing and updated the checkDeps function to pull in proper dependencies.

* Created an uninstall script with prompts to confirm removal of tuxc from the system and all dependencies respectively.

* Moved both scripts into a dedicated directory 'INSTALL'